### PR TITLE
Adds ability to url-encode specific regex groups in quip

### DIFF
--- a/helga_quip/plugin.py
+++ b/helga_quip/plugin.py
@@ -39,6 +39,12 @@ def _quip_manage(client, channel, nick, message, args):
             db.helga_quip.entries.remove(phrase)
     return random_ack()
 
+def _quote_groupdict(groupdict, quotelist):
+    return dict(map(lambda (k,v): urllib.quote(v) if k in quotelist else v, groupdict));
+
+def _quote_group(group, quotelist):
+    return _quote_groupdict(zip(map(str,range(len(group))), group), quotelist)
+
 def _quip_respond(message):
     """ Search for matching quip, respond if exists """
     for phrase in db.helga_quip.entries.find():

--- a/helga_quip/plugin.py
+++ b/helga_quip/plugin.py
@@ -65,7 +65,7 @@ def _quip_respond(message):
             # take care of backreferenced named groups, ez mode
             if result.groupdict():
                 try:
-                    quip = quip.format(**result.groupdict())
+                    quip = quip.format(**_quote_groupdict(result.groupdict()))
                 except IndexError:
                     # really python, no partial format support? i have
                     # to write my own formatter (using different $ syntax) or
@@ -74,7 +74,7 @@ def _quip_respond(message):
                     pass
             # take care of positional arguments
             else:
-                quip = quip.format(*result.groups())
+                quip = quip.format(*_quote_group(result.groups()))
             return ('success', quip)
 
 @match(_quip_respond)

--- a/helga_quip/plugin.py
+++ b/helga_quip/plugin.py
@@ -21,7 +21,13 @@ def _quip_manage(client, channel, nick, message, args):
         r = requests.post("http://dpaste.com/api/v2/", payload)
         return r.headers['location']
     else:
-        phrase = {'kind':args[1], 'regex':args[2]}
+        valid_options=["-q"]
+
+        # Filter out any option that is invalid and turn them into a
+        # dict
+        options = dict(map(lambda o: (o[:2], o[2:]), filter(lambda o: o[:2] in valid_options, args[3:])))
+        
+        phrase = {'kind':args[1], 'regex':args[2], 'options':options}
         if args[0] == 'add':
             phrase['nick'] = nick
             try:

--- a/helga_quip/plugin.py
+++ b/helga_quip/plugin.py
@@ -4,7 +4,7 @@ from helga import log
 from helga.db import db
 from helga.plugins import command, match, random_ack
 
-from helga_quip.util import quote_groupdict, quote_group
+from helga_quip.util import quote_groupdict, quote_group, pretty_map
 
 _help_text = 'Match quips and other witticisms. Usage:\
 !quip add/remove <quip_kind> <quip_regex>\
@@ -19,7 +19,7 @@ def _quip_manage(client, channel, nick, message, args):
     if args[0] == 'drop':
         db.helga_quip.entries.drop()
     elif args[0] == 'dump':
-        quips = [p['regex'] + ' | ' + p['kind'] for p in db.helga_quip.entries.find()]
+        quips = [p['regex'] + ' | ' + p['kind'] + ' | ' + pretty_map(p['options']) for p in db.helga_quip.entries.find()]
         if not quips:
             return "Quip database empty"
         payload = {'title':'helga-quip dump', 'content': '\n'.join(quips)}

--- a/helga_quip/plugin.py
+++ b/helga_quip/plugin.py
@@ -51,6 +51,12 @@ def _quip_respond(message):
         result = re.search(phrase['regex'], message, re.I)
         if result:
             quip = phrase['kind']
+
+            # get the quote list option; if it doesn't exist set it to
+            # empty list.
+            quotelist = phrase['options']['-q']
+            quotelist = quotelist.split(",") if quotelist else []
+
             # TODO this will handle either named groups or positional. it needs
             # some work to support hybrid backreferenced named and positonal
             # groups, but I may implement in the near future. putting in this

--- a/helga_quip/util.py
+++ b/helga_quip/util.py
@@ -7,3 +7,6 @@ def quote_group(group, quotelist):
     if group is None:
         group = []
     return [urllib.quote(v) if k in quotelist else v for (k, v) in zip(map(str, range(len(group))), group)]
+
+def pretty_map(m):
+    return " ; ".join(map(lambda (k,v): "{0}: {1}".format(k, v), m.iteritems()));

--- a/helga_quip/util.py
+++ b/helga_quip/util.py
@@ -1,0 +1,9 @@
+import urllib
+
+def quote_groupdict(groupdict, quotelist):
+    return dict(map(lambda (k,v): (k, urllib.quote(v)) if k in quotelist else (k, v), groupdict.iteritems()));
+
+def quote_group(group, quotelist):
+    if group is None:
+        group = []
+    return [urllib.quote(v) if k in quotelist else v for (k, v) in zip(map(str, range(len(group))), group)]

--- a/helga_quip/util.py
+++ b/helga_quip/util.py
@@ -1,12 +1,22 @@
+"""
+Utility methods used in helga_quip.plugin
+"""
+
 import urllib
 
 def quote_groupdict(groupdict, quotelist):
-    return dict(map(lambda (k,v): (k, urllib.quote(v)) if k in quotelist else (k, v), groupdict.iteritems()));
+    """Quotes (url-encodes) the items in groupdict whos key is in quotelist"""
+    return dict((k, urllib.quote(v)) if k in quotelist else (k, v)
+                for (k, v) in groupdict.iteritems())
 
 def quote_group(group, quotelist):
+    """Quotes (url-encodes) the items in group whose index is in quotelist"""
     if group is None:
         group = []
-    return [urllib.quote(v) if k in quotelist else v for (k, v) in zip(map(str, range(len(group))), group)]
+    return [urllib.quote(v) if k in quotelist else v
+            for (k, v) in zip((str(s) for s in range(len(group))), group)]
 
-def pretty_map(m):
-    return " ; ".join(map(lambda (k,v): "{0}: {1}".format(k, v), m.iteritems()));
+def pretty_map(inmap):
+    """Returns a pretty-formatted string representing the input map"""
+    return " ; ".join(["{0}: {1}".format(k, v)
+                       for (k, v) in inmap.iteritems()])

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,10 @@ from setuptools import setup, find_packages
 
 from pip.req import parse_requirements
 from helga_quip import __version__ as version
+from pip.download import PipSession
 
 requirements = [
-    str(req.req) for req in parse_requirements('requirements.txt')
+    str(req.req) for req in parse_requirements('requirements.txt', session=PipSession())
 ]
 
 setup(
@@ -27,9 +28,10 @@ setup(
     license='LICENSE',
     packages=find_packages(),
     include_package_data=True,
+    py_modules=['helga_quip.plugin'],
     zip_safe=True,
     install_requires=requirements,
-    test_suite='',
+    test_suite='tests.test_util',
     entry_points = dict(
         helga_plugins=[
             'quip = helga_quip.plugin:quip',

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,31 @@
+import urllib
+
+from helga_quip.util import quote_groupdict, quote_group
+from unittest import TestCase
+
+class TestUtilMethods(TestCase):
+
+    quoteList1 = ['a']
+    groupdict1 = {'a': '12?\/ # 456 ', 'b': '# $ ? 7412 asd'}
+    quoteList2 = ['1']
+    group1 = ['twas\' /brillig', '12? \/ # 456 ', 'and the slithy toves']
+    
+    def test_quote_groupdict(self):
+        result = quote_groupdict(self.groupdict1, self.quoteList1)
+        self.assertEqual(result['a'], urllib.quote(self.groupdict1['a']))
+        self.assertEqual(result['b'], self.groupdict1['b'])
+
+    def test_quote_group(self):
+        result = quote_group(self.group1, self.quoteList2)
+        self.assertEqual(result[1], urllib.quote(self.group1[1]))
+        self.assertEqual(self.group1[0], result[0])
+        self.assertEqual(self.group1[2], result[2])
+
+    def test_quote_group_empty(self):
+        result = quote_group(None, [])
+        quip = "foo".format(*result)
+        self.assertEqual("foo", quip)
+        
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Using -q, users can now specify regular expression groups they want to quote (url encode (percent encode)).

For example, !quip "http://lmgtfy.com/?q={0}" "(how do I .*)" -q0

Also adds a rudimentary options system for the add/remove commands
